### PR TITLE
Fix to clear()

### DIFF
--- a/library/scrollphathd/is31fl3731.py
+++ b/library/scrollphathd/is31fl3731.py
@@ -135,6 +135,8 @@ class Matrix:
 
         """
 
+        self._current_frame = 0
+        self._scroll = [0,0]
         del self.buf
         self.buf = numpy.zeros((self.width, self.height))
 


### PR DESCRIPTION
Added line 138 - 139 to reset scroll buffer.

If scrolling text, then subsequently clear() and use fill() or set_pixel(), display not mapping correctly and general odd behaviour