### PR TITLE
Portrait fix v3

### DIFF
--- a/examples/portraitclock.py
+++ b/examples/portraitclock.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import time
+import signal
+
+import scrollphathd
+from scrollphathd.fonts import font5x5
+
+print("""
+Scroll pHAT HD: Portrait Clock
+
+Displays hours, minutes and seconds in text.
+
+Press Ctrl+C to exit!
+
+""")
+
+BRIGHTNESS = 0.5
+
+scrollphathd.rotate(270)
+
+while True:
+    scrollphathd.clear()
+
+    str_time = time.strftime("%H") 
+    scrollphathd.write_string(str_time, x=0, y=0, font=font5x5, brightness=0.5)
+
+    str_time = time.strftime("%M")
+    scrollphathd.write_string(str_time, x=0, y=6, font=font5x5, brightness=0.5)
+
+    str_time = time.strftime("%S")
+    scrollphathd.write_string(str_time, x=0, y=12, font=font5x5, brightness=0.5)
+
+    scrollphathd.show()
+    time.sleep(0.1)
+

--- a/library/scrollphathd/is31fl3731.py
+++ b/library/scrollphathd/is31fl3731.py
@@ -326,7 +326,7 @@ class Matrix:
 
         for x in range(self.width):
             for y in range(self.height):
-                idx = self._pixel_addr(x, 6-y)
+                idx = self._pixel_addr(x, self.height-(y+1))
 
                 try:
                     output[idx] = int(display_buffer[x][y])

--- a/library/scrollphathd/is31fl3731.py
+++ b/library/scrollphathd/is31fl3731.py
@@ -37,7 +37,7 @@ class Matrix:
     height = 7
 
     def __init__(self, i2c, address=0x74):
-        self.buf = numpy.zeros((self.width, self.height))
+        self.buf = numpy.zeros((max(self.width, self.height), max(self.width, self.height)))
         self.i2c = i2c
         self.address = address
         self._reset()
@@ -136,7 +136,7 @@ class Matrix:
         """
 
         del self.buf
-        self.buf = numpy.zeros((self.width, self.height))
+        self.buf = numpy.zeros((max(self.width, self.height), max(self.width, self.height)))
 
     def draw_char(self, x, y, char, font=None, brightness=1.0):
         """Draw a single character to the buffer.
@@ -311,7 +311,10 @@ class Matrix:
                 display_buffer = numpy.roll(display_buffer, -self._scroll[axis], axis=axis)
 
         # Chop a width * height window out of the display buffer
-        display_buffer = display_buffer[:self.width, :self.height]
+        if self._rotate%2:
+            display_buffer = display_buffer[:self.height, :self.width]
+        else:
+            display_buffer = display_buffer[:self.width, :self.height]
 
         if self._rotate:
             display_buffer = numpy.rot90(display_buffer, self._rotate)


### PR DESCRIPTION
Fix 90 and 270 degree rotations.

The buffer is cropped before rotation, such that it will be the right shape after it is rotated. The initial buffer size is square, and big enough to fit the physical display in either orientation. Also adds a portrait clock example.

Fixes #5.