### PR TITLE
Fix flip direction.

### DIFF
--- a/library/scrollphathd/is31fl3731.py
+++ b/library/scrollphathd/is31fl3731.py
@@ -328,14 +328,14 @@ class Matrix:
         else:
             display_buffer = display_buffer[:self.width, :self.height]
 
-        if self._rotate:
-            display_buffer = numpy.rot90(display_buffer, self._rotate)
-
-        if self._flipy:
+        if self._flipx:
             display_buffer = numpy.flipud(display_buffer)
 
-        if self._flipx:
+        if self._flipy:
             display_buffer = numpy.fliplr(display_buffer)
+
+        if self._rotate:
+            display_buffer = numpy.rot90(display_buffer, self._rotate)
 
         output = [0 for x in range(144)]
 


### PR DESCRIPTION
Calling numpy.zeros((2,3)) gives an array like this:

array([[ 0.,  0.,  0.],
       [ 0.,  0.,  0.]])

Flipping this left to right flips it in the long axis, i.e. the
"y" axis. This means that either every reference to array indices
must be swapped around, or we can just reverse fliplr/flipud calls.

Also, flipping must be done before rotation to make it consistent
through all orientations.