### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/scrollphathd/__init__.py
+++ b/library/scrollphathd/__init__.py
@@ -1,32 +1,13 @@
-import atexit
-from sys import exit, version_info
-
-try:
-    import smbus
-except ImportError:
-    if version_info[0] < 3:
-        exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
-    elif version_info[0] == 3:
-        exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
+from sys import version_info
 
 from . import is31fl3731
 
 __version__ = '1.0.1'
 
-i2c = None
+display = is31fl3731.ScrollPhatHD(None, gamma_table=is31fl3731.LED_GAMMA)
 
-try:
-    i2c = smbus.SMBus(1)
-except IOError as e:
-    if hasattr(e,"errno") and e.errno == 2:
-        e.strerror += "\n\nMake sure you've enabled i2c in your Raspberry Pi configuration.\n"
-    raise e
-
-display = is31fl3731.ScrollPhatHD(i2c, gamma_table=is31fl3731.LED_GAMMA)
-_clear_on_exit = True
-
-DISPLAY_HEIGHT = 7
-DISPLAY_WIDTH = 17
+DISPLAY_HEIGHT = display._height
+DISPLAY_WIDTH = display._width
 
 pixel = display.set_pixel
 set_pixel = display.set_pixel
@@ -46,26 +27,5 @@ clear = display.clear
 set_graph = display.set_graph
 get_buffer_shape = display.get_buffer_shape
 get_shape = display.get_shape
+set_clear_on_exit = display.set_clear_on_exit
 
-def set_clear_on_exit(value=True):
-    """Set whether Scroll pHAT HD should be cleared upon exit.
-
-    By default Scroll pHAT HD will turn off the pixels on exit, but calling::
-
-        scrollphathd.set_clear_on_exit(False)
-
-    Will ensure that it does not.
-
-    :param value: True or False (default True)
-
-    """
-
-    global _clear_on_exit
-    _clear_on_exit = value
-
-def _exit():
-    if _clear_on_exit:
-        display.clear()
-        display.show()
-
-atexit.register(_exit)


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Scroll pHAT HD library to avoid code being unnecessarily executed upon import.

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488