### PR TITLE
Include link to Go lib in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ In all cases you will have to enable the i2c bus.
 
 * Java library by Jim Darby - https://github.com/hackerjimbo/PiJava
 * Rust library by Tiziano Santoro - https://github.com/tiziano88/scroll-phat-hd-rs
+* Go library by Tom Mitchell - https://github.com/tomnz/scroll-phat-hd-go


### PR DESCRIPTION
Have ported all the low level device code to use [periph.io](https://periph.io) for native I2C bus communication in Go. Tested working on my own pHAT (attached to Pi Zero W).

I've also started building out a higher-level wrapper struct that provides similar functionality to the Python library (auto-expanding buffer, scrolling, flipping, etc). This is still a WIP, but I feel like it's in a good enough place for more folks to use.