### PR TITLE
async argument is now is_async

### DIFF
--- a/examples/twitter-hashtag.py
+++ b/examples/twitter-hashtag.py
@@ -97,7 +97,7 @@ api = tweepy.API(auth)
 myStreamListener = MyStreamListener()
 myStream = tweepy.Stream(auth=api.auth, listener=myStreamListener)
 
-myStream.filter(track=[keyword], stall_warnings=True, async=True)
+myStream.filter(track=[keyword], stall_warnings=True, is_async=True)
 
 
 try:


### PR DESCRIPTION
I was playing around with the examples and I ran into an issue with this one where I was getting the error that the argument `async` was unexpected. It looks like it has been renamed to `is_async` and this runs now. This may break things with older versions however. 