### PR TITLE
Add back in set_font method

### DIFF
--- a/examples/unicode-scrolling.py
+++ b/examples/unicode-scrolling.py
@@ -16,6 +16,13 @@ single messages across the display.
 Press Ctrl+C to exit.
 """)
 
+# For python 2/3 compatibility, check to see if `unichr` is defined.
+# If it isn't, then this is python3, in which case the `chr` builtin can
+# be used instead.
+try:
+    unichr
+except NameError:
+    unichr = chr
 
 def scroll_message(message):
     scrollphathd.clear()                         # Clear the display and reset scrolling to (0, 0)

--- a/library/scrollphathd/__init__.py
+++ b/library/scrollphathd/__init__.py
@@ -339,6 +339,17 @@ def flip(x=False, y=False):
     _flipy = y
 
 
+def set_font(self, font):
+    """Set a global font value.
+
+    :param font: Font value from .font (font3x5, font5x5, font5x7, font5x7smoothed)
+
+    Note: Import the font before invoking set_font(), (available by) default is font5x7.
+    """
+    global _font
+    _font = font
+
+
 def draw_char(x, y, char, font=None, brightness=1.0, monospaced=False):
     """Draw a single character to the buffer.
 


### PR DESCRIPTION
Some examples seem to rely on a `set_font` method (probably the one added in this commit: https://github.com/pimoroni/scroll-phat-hd/commit/a842628b4745b85a3e21a8e5269021f9a6655059#diff-f0bbcb15cc384b33127937e4e173fdc0 but it seems to have gone missing in the latest version of the code. 

This PR adds the method back in, using the `_font` global to hold the default font state. It also changes the `unicode-scrolling` example to be py2/py3 agnostic by switching between `unichr` / `chr` as appropriate. 