### PR TITLE
fix StoppableThread issue in Python 3.9+

### DIFF
--- a/library/scrollphathd/api/stoppablethread.py
+++ b/library/scrollphathd/api/stoppablethread.py
@@ -10,11 +10,11 @@ class StoppableThread(threading.Thread):
         self.daemon = True
 
     def start(self):
-        if not self.isAlive():
+        if not self.is_alive():
             self.stop_event.clear()
             threading.Thread.start(self)
 
     def stop(self):
-        if self.isAlive():
+        if self.is_alive():
             self.stop_event.set()
             self.join()


### PR DESCRIPTION
Running some of the examples on Bullseye and Python 3.9+ causes an error:

`'StoppableThread' object has no attribute 'isAlive'`

It turns out that the threading.Thread module removed `isAlive` in Python 3.9, replaced with `is_alive()`, and that fixing this is a backwards-compatible change [as far back as Python 2.6](https://docs.python.org/2/library/threading.html#threading.Thread.is_alive).
